### PR TITLE
Focus repo exclusively on novel writing with optimized chapter length

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Kimi Writing Agent
 
-An autonomous agent powered by the **kimi-k2-thinking** model for creating novels, books, and short story collections.
+An autonomous agent powered by the **kimi-k2-thinking** model for creating novels and books.
 
 ## Features
 
 - 🤖 **Autonomous Writing**: The agent plans and executes creative writing tasks independently
-- 📚 **Multiple Formats**: Create novels, books, or short story collections
+- 📚 **Novel Writing**: Create complete novels with multiple chapters
 - ⚡ **Real-Time Streaming**: See the agent's reasoning and writing appear as it's generated
 - 💾 **Smart Context Management**: Automatically compresses context when approaching token limits
 - 🔄 **Recovery Mode**: Resume interrupted work from saved context summaries
@@ -62,10 +62,10 @@ MOONSHOT_BASE_URL=https://api.moonshot.ai/v1
 Run with an inline prompt:
 ```bash
 # Using uv (recommended)
-uv run kimi-writer.py "Create a collection of 5 sci-fi short stories about AI"
+uv run kimi-writer.py "Create a sci-fi novel with 12 chapters about AI"
 
 # Or using python directly
-python kimi-writer.py "Create a collection of 5 sci-fi short stories about AI"
+python kimi-writer.py "Create a sci-fi novel with 12 chapters about AI"
 ```
 
 Or run interactively:
@@ -128,28 +128,29 @@ kimi-writer/
 └── README.md             # This file
 
 # Generated during use:
-output/                   # All AI-generated projects go here
-├── your_project_name/    # Created by the agent
+output/                   # All AI-generated novels go here
+├── your_novel_name/      # Created by the agent
 │   ├── chapter_01.md     # Written by the agent
 │   ├── chapter_02.md
+│   ├── chapter_03.md
 │   └── .context_summary_*.md  # Auto-saved context summaries
-└── another_project/
+└── another_novel/
     └── ...
 ```
 
 ## Examples
 
-### Example 1: Novel
+### Example 1: Mystery Novel
 ```bash
 uv run kimi-writer.py "Write a mystery novel set in Victorian London with 10 chapters"
 ```
 
-### Example 2: Short Story Collection
+### Example 2: Science Fiction Novel
 ```bash
-uv run kimi-writer.py "Create 7 interconnected sci-fi short stories exploring the theme of memory"
+uv run kimi-writer.py "Create a sci-fi novel with 12 chapters exploring the theme of memory and identity"
 ```
 
-### Example 3: Book
+### Example 3: Non-Fiction Book
 ```bash
 uv run kimi-writer.py "Write a comprehensive guide to Python programming with 15 chapters"
 ```
@@ -159,7 +160,7 @@ uv run kimi-writer.py "Write a comprehensive guide to Python programming with 15
 ### Real-Time Streaming
 Watch the agent think and write in real-time:
 - 🧠 **Reasoning Stream**: See the agent's thought process as it plans
-- 💬 **Content Stream**: Watch stories being written character by character
+- 💬 **Content Stream**: Watch chapters being written character by character
 - 🔧 **Tool Call Progress**: Live updates when generating large content (shows character/word count)
 - ⚡ **No Waiting**: Immediate feedback - no more staring at a blank screen
 

--- a/kimi-writer.py
+++ b/kimi-writer.py
@@ -2,8 +2,8 @@
 """
 Kimi Writing Agent - An autonomous agent for creative writing tasks.
 
-This agent uses the kimi-k2-thinking model to create novels, books, 
-and short story collections based on user prompts.
+This agent uses the kimi-k2-thinking model to create novels and books
+based on user prompts.
 """
 
 import os
@@ -62,13 +62,13 @@ def get_user_input() -> tuple[str, bool]:
         Tuple of (prompt/context, is_recovery_mode)
     """
     parser = argparse.ArgumentParser(
-        description="Kimi Writing Agent - Create novels, books, and short stories",
+        description="Kimi Writing Agent - Create novels and books",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
   # Fresh start with inline prompt
-  python kimi-writer.py "Create a collection of sci-fi short stories"
-  
+  python kimi-writer.py "Create a sci-fi novel with 12 chapters"
+
   # Recovery mode from previous context
   python kimi-writer.py --recover my_project/.context_summary_20250107_143022.md
         """
@@ -101,7 +101,7 @@ Examples:
     print("Kimi Writing Agent")
     print("=" * 60)
     print("\nEnter your writing request (or 'quit' to exit):")
-    print("Example: Create a collection of 15 sci-fi short stories\n")
+    print("Example: Create a sci-fi novel with 15 chapters\n")
     
     prompt = input("> ").strip()
     

--- a/utils.py
+++ b/utils.py
@@ -158,7 +158,7 @@ def get_system_prompt() -> str:
     Returns:
         System prompt string
     """
-    return """You are Kimi, an expert creative writing assistant developed by Moonshot AI. Your specialty is creating novels, books, and collections of short stories based on user requests.
+    return """You are Kimi, an expert creative writing assistant developed by Moonshot AI. Your specialty is creating novels and books based on user requests.
 
 Your capabilities:
 1. You can create project folders to organize writing projects
@@ -167,27 +167,24 @@ Your capabilities:
 
 CRITICAL WRITING GUIDELINES:
 - Write SUBSTANTIAL, COMPLETE content - don't hold back on length
-- Short stories should be 3,000-10,000 words (10-30 pages) - write as much as the story needs!
-- Chapters should be 2,000-5,000 words minimum - fully developed and satisfying
-- NEVER write abbreviated or skeleton content - every piece should be a complete, polished work
+- Chapters should be 2,500-3,500 words - fully developed and satisfying
+- NEVER write abbreviated or skeleton content - every chapter should be a complete, polished work
 - Don't summarize or skip scenes - write them out fully with dialogue, description, and detail
 - Quality AND quantity matter - give readers a complete, immersive experience
-- If a story needs 8,000 words to be good, write all 8,000 words in one file
 - Use 'create' mode with full content rather than creating stubs you'll append to later
 
 Best practices:
 - Always start by creating a project folder using create_project
-- Break large works into multiple files (chapters, stories, etc.)
-- Use descriptive filenames (e.g., "chapter_01.md", "story_the_last_star.md")
-- For collections, consider creating a table of contents file
-- Write each file as a COMPLETE, SUBSTANTIAL piece - not a summary or outline
+- Break novels into multiple chapter files
+- Use descriptive filenames (e.g., "chapter_01.md", "chapter_02.md")
+- Write each chapter as a COMPLETE, SUBSTANTIAL piece - not a summary or outline
 
 Your workflow:
 1. Understand the user's request
 2. Create an appropriately named project folder
-3. Plan the structure of the work (chapters, stories, etc.)
-4. Write COMPLETE, FULL-LENGTH content for each file
+3. Plan the structure of the novel (number of chapters, arc, etc.)
+4. Write COMPLETE, FULL-LENGTH content for each chapter
 5. Create supporting files like README or table of contents if helpful
 
-REMEMBER: You have 64K tokens per response - use them! Write rich, detailed, complete stories. Don't artificially limit yourself. A good short story is 5,000-10,000 words. A good chapter is 3,000-5,000 words. Write what the narrative needs to be excellent."""
+REMEMBER: You have 64K tokens per response - use them! Write rich, detailed, complete chapters. Don't artificially limit yourself. A good chapter is 2,500-3,500 words. Write what the narrative needs to be excellent."""
 


### PR DESCRIPTION
- Remove all short story references from codebase
- Update chapter word count to 2,500-3,500 words (from 2,000-5,000)
- Simplify system prompt to focus on novels and books only
- Update README examples to showcase novel writing
- Streamline user-facing documentation and CLI examples